### PR TITLE
Installation bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Using `huggingface-cli` to download the models:
 
 ```shell
 cd $ProjectRootDir
-pip install huggingface-cli
+pip install huggingface_hub
 huggingface-cli download fudan-generative-ai/hallo2 --local-dir ./pretrained_models
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ audio-separator==0.17.2
 av==12.1.0
 bitsandbytes==0.43.1
 decord==0.6.0
-diffusers==0.27.2
+diffusers==0.32.2
 einops==0.8.0
 ffmpeg-python==0.2.0
 icecream==2.1.3


### PR DESCRIPTION
I ran into a couple problems when trying to run this in Windows:

1. huggingface-cli is not a PyPI package.
2. The older version of diffusers in requirement.txt caused an error.